### PR TITLE
Fixed underline under social links

### DIFF
--- a/index.css
+++ b/index.css
@@ -31,6 +31,10 @@ body{
     -webkit-tap-highlight-color: transparent;
 }
 
+a{
+  text-decoration: none;
+}
+
 .none{
     display: none;
 }


### PR DESCRIPTION
added
a{
  text-decoration: none;
}
to remove the blue-underline under social links in footer on main page